### PR TITLE
[Option 1] Fix race between `handle_replica_event` and `start_pid_remotely`

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1353,7 +1353,7 @@ defmodule Swarm.Tracker do
           )
 
           # register named process that is unknown locally
-          add_registration({name, pid, meta}, from, state)
+          GenStateMachine.call(__MODULE__, {:track, name, pid, meta}, :infinity)
           :ok
 
         {:error, {:noproc, _}} = err ->

--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1134,6 +1134,10 @@ defmodule Swarm.Tracker do
     add_registration({name, pid, meta}, from, state)
   end
 
+  defp handle_call({:add_registration, name, pid, meta, from}, _from, %TrackerState{} = state) do
+    add_registration({name, pid, meta}, from, state)
+  end
+
   defp handle_call({:track, name, meta}, from, state) do
     current_node = Node.self()
     {{m, f, a}, _other_meta} = Map.pop(meta, :mfa)
@@ -1353,7 +1357,7 @@ defmodule Swarm.Tracker do
           )
 
           # register named process that is unknown locally
-          GenStateMachine.call(__MODULE__, {:track, name, pid, meta}, :infinity)
+          GenStateMachine.call(__MODULE__, {:add_registration, name, pid, meta, from}, :infinity)
           :ok
 
         {:error, {:noproc, _}} = err ->


### PR DESCRIPTION
There appears to be a race condition leading the `Swarm.Tracker` process to die. When this happens the monitors that were acquired by `Swarm.Tracker` are lost and the process `:down` events will fail to be captured.

The race occurs when `handle_replica_event` attempts to find the remote process in the local registry. If it is not found, but is then registered in the mean time by `start_pid_remotely` an error will occur when `handle_replica_event` tries to register the process itself

https://github.com/scorebet/swarm/blob/7dd08d6d41fd77c447c99e07e62898ffcd757684/lib/swarm/tracker/tracker.ex#L1004-L1008

This solution attempts to remedy the problem by serializing the call to `add_registration` by `start_pid_remotely` within the Tracker GenStateMachine process. This will prevent the registration from executing concurrently with `handle_replica_event` 
