### PR TITLE
[Option 2] Fix race between `handle_replica_event` and `start_pid_remotely`

### DIFF
--- a/lib/swarm/tracker/tracker.ex
+++ b/lib/swarm/tracker/tracker.ex
@@ -1352,9 +1352,10 @@ defmodule Swarm.Tracker do
             "#{inspect(name)} already registered to #{inspect(pid)} on #{node(pid)}, registering locally"
           )
 
-          # register named process that is unknown locally
-          add_registration({name, pid, meta}, from, state)
-          :ok
+          case from do
+            nil -> :ok
+            _   -> GenStateMachine.reply(from, {:ok, pid})
+          end
 
         {:error, {:noproc, _}} = err ->
           warn(


### PR DESCRIPTION
There appears to be a race condition leading the `Swarm.Tracker` process to die. When this happens the monitors that were acquired by `Swarm.Tracker` are lost and the process `:down` events will fail to be captured.

The race occurs when `handle_replica_event` attempts to find the remote process in the local registry. If it is not found, but is then registered in the mean time by `start_pid_remotely` an error will occur when `handle_replica_event` tries to register the process itself

https://github.com/scorebet/swarm/blob/7dd08d6d41fd77c447c99e07e62898ffcd757684/lib/swarm/tracker/tracker.ex#L1004-L1008

This solution removes the call to `add_registration` from `start_pid_remotely` to remove the potential race condition. This reintroduces the issue https://github.com/bitwalker/swarm/issues/45 fixed by https://github.com/bitwalker/swarm/pull/46. Option 1 may be preferable.
